### PR TITLE
msm: platsmp-8625: cleanup macro names

### DIFF
--- a/arch/arm/mach-msm/lge/vee7/board-msm7x27a_vee7.c
+++ b/arch/arm/mach-msm/lge/vee7/board-msm7x27a_vee7.c
@@ -1000,7 +1000,7 @@ static void __init msm7x27a_reserve(void)
 static void __init msm8625_reserve(void)
 {
 	msm7x27a_reserve();
-	memblock_remove(MSM8625_SECONDARY_PHYS, SZ_8);
+	memblock_remove(MSM8625_CPU_PHYS, SZ_8);
 	memblock_remove(MSM8625_WARM_BOOT_PHYS, SZ_32);
 	memblock_remove(MSM8625_NON_CACHE_MEM, SZ_2K);
 }


### PR DESCRIPTION
All the macros defined for 8625 secondary core indicates dual
core. Cleanup macros to be more generic to fit for multi core.

Change-Id: Ia21b2fe6e4a980ae1d60729ceb4085d1a72a16d3
Signed-off-by: Taniya Das tdas@codeaurora.org
Signed-off-by: Caio99BR caiooliveirafarias0@gmail.com
